### PR TITLE
Stream reset refinements

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -2,7 +2,12 @@ package sctp
 
 import (
 	"fmt"
+	"net"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/pions/transport/test"
 )
 
 func TestAssociationInit(t *testing.T) {
@@ -20,112 +25,202 @@ func TestAssociationInit(t *testing.T) {
 	}
 }
 
-// TODO: find a good way to avoid deadlocking in the test
-// func TestStressDuplex(t *testing.T) {
-// 	// Limit runtime in case of deadlocks
-// 	lim := test.TimeOut(time.Second * 20)
-// 	defer lim.Stop()
-//
-// 	// Check for leaking routines
-// 	report := test.CheckRoutines(t)
-// 	defer report()
-//
-// 	// Run the test
-// 	stressDuplex(t)
-// }
-//
-// func stressDuplex(t *testing.T) {
-// 	lim := test.TimeOut(time.Second * 5)
-// 	defer lim.Stop()
-//
-// 	ca, cb, stop, err := pipeMemory()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-//
-// 	defer stop(t)
-//
-// 	opt := test.Options{
-// 		MsgSize:  2048,
-// 		MsgCount: 50,
-// 	}
-//
-// 	err = test.StressDuplex(ca, cb, opt)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// }
-//
-// func pipeMemory() (*Stream, *Stream, func(*testing.T), error) {
-// 	var err error
-//
-// 	var aa, ab *Association
-// 	aa, ab, err = associationMemory()
-// 	if err != nil {
-// 		return nil, nil, nil, err
-// 	}
-//
-// 	var sa, sb *Stream
-// 	sa, err = aa.OpenStream(0, 0)
-// 	if err != nil {
-// 		return nil, nil, nil, err
-// 	}
-//
-// 	sb, err = ab.OpenStream(0, 0)
-// 	if err != nil {
-// 		return nil, nil, nil, err
-// 	}
-//
-// 	stop := func(t *testing.T) {
-// 		err = sa.Close()
-// 		if err != nil {
-// 			t.Error(err)
-// 		}
-// 		err = sb.Close()
-// 		if err != nil {
-// 			t.Error(err)
-// 		}
-// 		err = aa.Close()
-// 		if err != nil {
-// 			t.Error(err)
-// 		}
-// 		err = ab.Close()
-// 		if err != nil {
-// 			t.Error(err)
-// 		}
-// 	}
-//
-// 	return sa, sb, stop, nil
-// }
-//
-// func associationMemory() (*Association, *Association, error) {
-// 	// In memory pipe
-// 	ca, cb := test.PacketPipe(100) // TODO: Find a better way to avoid blocking
-//
-// 	type result struct {
-// 		a   *Association
-// 		err error
-// 	}
-//
-// 	c := make(chan result)
-//
-// 	// Setup client
-// 	go func() {
-// 		client, err := Client(ca)
-// 		c <- result{client, err}
-// 	}()
-//
-// 	// Setup server
-// 	server, err := Server(cb)
-// 	if err != nil {
-// 		return nil, nil, err
-// 	}
-//
-// 	// Receive client
-// 	res := <-c
-// 	if res.err != nil {
-// 		return nil, nil, res.err
-// 	}
-//
-// 	return res.a, server, nil
-// }
+func TestStressDuplex(t *testing.T) {
+	// Limit runtime in case of deadlocks
+	lim := test.TimeOut(time.Second * 20)
+	defer lim.Stop()
+
+	// Check for leaking routines
+	report := test.CheckRoutines(t)
+	defer report()
+
+	stressDuplex(t)
+}
+
+func stressDuplex(t *testing.T) {
+	ca, cb, stop, err := pipe(pipeDump)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer stop(t)
+
+	// TODO: Increase once SCTP is more reliable in case of slow reader
+	opt := test.Options{
+		MsgSize:  2048, // 65535,
+		MsgCount: 10,   // 1000,
+	}
+
+	err = test.StressDuplex(ca, cb, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func pipe(piper piperFunc) (*Stream, *Stream, func(*testing.T), error) {
+	var err error
+
+	var aa, ab *Association
+	aa, ab, err = association(piper)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var sa, sb *Stream
+	sa, err = aa.OpenStream(0, 0)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	sb, err = ab.OpenStream(0, 0)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	stop := func(t *testing.T) {
+		err = sa.Close()
+		if err != nil {
+			t.Error(err)
+		}
+		err = sb.Close()
+		if err != nil {
+			t.Error(err)
+		}
+		err = aa.Close()
+		if err != nil {
+			t.Error(err)
+		}
+		err = ab.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	return sa, sb, stop, nil
+}
+
+func association(piper piperFunc) (*Association, *Association, error) {
+	ca, cb := piper()
+
+	type result struct {
+		a   *Association
+		err error
+	}
+
+	c := make(chan result)
+
+	// Setup client
+	go func() {
+		client, err := Client(ca)
+		c <- result{client, err}
+	}()
+
+	// Setup server
+	server, err := Server(cb)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Receive client
+	res := <-c
+	if res.err != nil {
+		return nil, nil, res.err
+	}
+
+	return res.a, server, nil
+}
+
+type piperFunc func() (net.Conn, net.Conn)
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func pipeDump() (net.Conn, net.Conn) {
+	aConn := acceptDumbConn()
+
+	bConn, err := net.DialUDP("udp4", nil, aConn.LocalAddr().(*net.UDPAddr))
+	check(err)
+
+	// Dumb handshake
+	mgs := "Test"
+	_, err = bConn.Write([]byte(mgs))
+	check(err)
+
+	b := make([]byte, 4)
+	_, err = aConn.Read(b)
+	check(err)
+
+	if string(b) != mgs {
+		panic("Dumb handshake failed")
+	}
+
+	return aConn, bConn
+}
+
+type dumbConn struct {
+	mu    sync.RWMutex
+	rAddr net.Addr
+	pConn net.PacketConn
+}
+
+func acceptDumbConn() *dumbConn {
+	pConn, err := net.ListenUDP("udp4", nil)
+	check(err)
+	return &dumbConn{
+		pConn: pConn,
+	}
+}
+
+// Read
+func (c *dumbConn) Read(p []byte) (int, error) {
+	i, rAddr, err := c.pConn.ReadFrom(p)
+	if err != nil {
+		return 0, err
+	}
+
+	c.mu.Lock()
+	c.rAddr = rAddr
+	c.mu.Unlock()
+
+	return i, err
+}
+
+// Write writes len(p) bytes from p to the DTLS connection
+func (c *dumbConn) Write(p []byte) (n int, err error) {
+	return c.pConn.WriteTo(p, c.RemoteAddr())
+}
+
+// Close closes the conn and releases any Read calls
+func (c *dumbConn) Close() error {
+	return c.pConn.Close()
+}
+
+// LocalAddr is a stub
+func (c *dumbConn) LocalAddr() net.Addr {
+	return c.pConn.LocalAddr()
+}
+
+// RemoteAddr is a stub
+func (c *dumbConn) RemoteAddr() net.Addr {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.rAddr
+}
+
+// SetDeadline is a stub
+func (c *dumbConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+// SetReadDeadline is a stub
+func (c *dumbConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+// SetWriteDeadline is a stub
+func (c *dumbConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/pions/sctp
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pions/transport v0.0.0-20190110151433-e7cbf7d5f464
 	github.com/pkg/errors v0.8.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,11 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pions/transport v0.0.0-20190110151433-e7cbf7d5f464 h1:/xAqYLQMIU2ci1fhEdgaFq1zc9E2p83+3a02LzUDRvQ=
+github.com/pions/transport v0.0.0-20190110151433-e7cbf7d5f464/go.mod h1:HLhzI7I0k8TyiQ99hfRZNRf84lG76eaFnZHnVy/wFnM=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
Some refinements for the stream reset PR:
- Added an E2E test for SCTP over UDP.
- Wait to reset the stream until we've received the last send packet indicated in the reset request.
- Make the read notification asynchronous so the association lock isn't locked for too long.
- Update the test dependency to a version that supports modules.